### PR TITLE
Link to the new docs

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -2,6 +2,10 @@
 	const nav = ['community', 'contribute', 'donate', 'docs', 'about', 'download'];
 
 	let showMobileMenu = false;
+
+	function getLinkUrl(link: string) {
+		return link === 'docs' ? 'https://docs.bitbanana.app' : `/${link}`;
+	}
 </script>
 
 <!-- desktop header -->
@@ -14,7 +18,7 @@
 
 	<nav class="flex space-x-12">
 		{#each nav as link}
-			<a href={'/' + link} class="font-semibold text-link hover:text-hover"
+			<a href={getLinkUrl(link)} class="font-semibold text-link hover:text-hover"
 				>{link.charAt(0).toUpperCase() + link.slice(1)}</a
 			>
 		{/each}
@@ -45,7 +49,7 @@
 	>
 		{#each nav.reverse() as link}
 			<a
-				href={'/' + link}
+				href={getLinkUrl(link)}
 				on:click={() => (showMobileMenu = false)}
 				class="block text-xl font-bold text-link hover:text-hover"
 				>{link.charAt(0).toUpperCase() + link.slice(1)}</a

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -7,11 +7,7 @@
 	<meta property="twitter:title" content="BitBanana - Docs" />
 </svelte:head>
 
-<Template
-	title="Docs"
-	link="https://github.com/michaelWuensch/BitBanana/wiki"
-	button="Read the Docs"
->
+<Template title="Docs" link="https://docs.bitbanana.app/" button="Read the Docs">
 	You can find detailed instructions on how to get your node setup using BitBanana in our
 	documentation. Community contributions to improve the docs are welcome!
 </Template>


### PR DESCRIPTION
Finally, BitBanana got the Docs it deserves!
This PR changes the links on the website to the new docs. It also links directly to the docs now instead of giving you an extra site that basically has nothing but a "Go to the docs" button.